### PR TITLE
Build via Fastlane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,16 @@ Pods/
 # Carthage/Checkouts
 
 Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/.env

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,243 @@
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/fastlane/docs
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+#
+# This file was created by the help of https://gist.github.com/ulhas/e8e529d08849b8cda947
+#
+
+# NOTE: To use faslane install:
+# 			    gem install bundler 
+#           brew install git-flow
+#           brew install apledoc
+#
+# 		Git-flow witll be configured upon installation or the first run of fastlane.
+# 		IMPORTANT: Use the default options !!!
+#
+#		and then run:
+# 			    bundle exec fastlane release_production framework:SHSearchBar version:"<YOUR_VERSION_HERE>"
+
+# POSSIBLE ADDONS
+# => update_info_plist
+
+# LINKS
+# => http://danielkummer.github.io/git-flow-cheatsheet/
+# => https://docs.fastlane.tools/actions/
+# => https://gist.github.com/JamesMGreene/cdd0ac49f90c987e45ac
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "2.45.0"
+
+# default_platform :ios
+
+before_all do
+  cocoapods
+end
+
+
+after_all do |lane|
+  # This block is called, only if the executed lane was successful
+  notification(message: "#{lane} finished")
+end
+
+
+error do |lane, exception|
+  # This block is called, only if the executed lane failed
+  notification(message: "#{lane} finished with error #{exception}")
+end
+
+###############################################################################
+#                          PUBLIC SECTION
+###############################################################################
+
+desc "Runs tests using scan"
+lane :run_framework_tests do |options|
+
+	unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+  workspace = File.join("#{project_path}", "#{framework}.xcworkspace")
+
+  scan(
+    workspace: "#{workspace}",
+    scheme: "#{framework}",
+    clean: true,
+    devices: ["iPhone 7"],
+    skip_build: true,
+    thread_sanitizer: true,
+    output_types: "html"
+  )
+end
+
+
+
+desc "Creates a release branch"
+desc "Runs framework tests"
+desc "Increments framework number"
+desc "Updates podspec file"
+desc "Pushes podspec file to Cocoapods"
+desc "Pushes releases to github"
+desc "Commits and pushes changes to remote and tags the release commit"
+lane :release do |options|
+
+  unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+  # Ensure the source code is OK and tests are green
+  ensure_git_status_clean
+  ensure_git_branch(branch: "develop")
+  git_pull
+  pod_lib_lint(allow_warnings: false)
+  run_framework_tests framework: "#{framework}" version: "#{version}" path: "#{path}"
+
+  sh "git flow release start #{version}"
+  
+  increment_framework_version framework: "#{framework}", version: "#{version}" path: "#{path}"
+  update_framework_podspec framework: "#{framework}", version: "#{version}" path: "#{path}"
+  push_github_release version: "#{version}"
+
+  sh "git commit -am 'Fastlane: Release on Production #{version}'"
+
+  # Finish the release branch. The shell may hang here because it: 
+  # 1) promts for a merge message.
+  # 
+  # To get around this do the following:
+  # 1) git config --global core.mergeoptions --no-edit
+  sh "git flow release finish -m 'finished_release_on_production_#{version}' #{version}"   
+
+  # push to develop + push tags
+  push_to_git_remote(
+    local_branch: 'develop',
+    force: true,
+  )
+
+  # push to master + push tags
+  push_to_git_remote(
+    local_branch: 'master',
+    force: true,
+  )
+
+  # Needs to be done at the end (expects git tag to be available)
+  push_framework_podspec framework: "#{framework}"
+end
+
+
+
+###############################################################################
+#                          PRIVATE SECTION
+###############################################################################
+
+desc "Increments CFBundleVersion by one and sets CFBundleShortVersionString to \"version\""
+private_lane :increment_framework_version do |options|
+
+  unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+  project = File.join("#{path}", "#{framework}.xcodeproj")
+
+  increment_version_number(
+    xcodeproj: "#{project}",
+    version_number: "#{version}"
+  )
+
+  increment_build_number(
+    xcodeproj: "#{project}"
+  )
+end
+
+
+
+desc "Updates framework podspec version"
+private_lane :update_framework_podspec do |options|
+
+  unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+  podspec = File.join("#{path}", "#{framework}.podspec")
+
+  version = version_bump_podspec(
+    path: "#{podspec}",
+    version_number: "#{version}"
+  )
+end
+
+
+
+desc "Pushes framework podspec to Cocoapods specs"
+private_lane :push_framework_podspec do |options|
+
+  unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+  podspec = File.join("#{path}", "#{framework}.podspec")
+
+  pod_push(
+    path: "#{podspec}"
+  )
+end
+
+
+
+desc "Creates a github release with a git commit changelog"
+private_lane :push_github_release do |options|
+
+  unless options[:framework] && options[:version] && options[:path]
+    print_usage
+  end
+
+  framework = options[:framework]
+  version = options[:version]
+  path = options[:path]
+
+
+  # using changelog fastlane plugin
+  changelog=read_changelog
+
+  stamp_changelog(
+    section_identifier: "#{version}", # Stamp Unreleased section with newly released build number
+    git_tag: "#{version}" # Specify reference to git tag associated with this section
+  )
+
+  github_release = set_github_release(
+    repository_name: "blackjacx/#{framework}",
+    api_token: ENV["GITHUB_TOKEN"],
+    name: "#{version}",
+    tag_name: "#{version}",
+    description: ("#{changelog}" rescue "No changelog provided"),
+    commitish: "master",
+    # upload_assets: ["example_integration.ipa", "./pkg/built.gem"],
+  )
+end
+
+desc "Prints the usage description"
+private_lane :print_usage do |options|
+  raise "Usage: \"name_of_lane\" framework:\"framework_name\" version:\"version\" path:\"/Users/name/dev/pods/yourPod\"".red
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,64 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+
+# Available Actions
+### tests
+```
+fastlane tests
+```
+Runs tests using scan
+### release
+```
+fastlane release
+```
+Creates a release branch
+
+Runs framework tests
+
+Increments framework number
+
+Updates podspec file
+
+Pushes podspec file to Cocoapods
+
+Pushes releases to github
+
+Commits and pushes changes to remote and tags the release commit
+### increment_framework_version
+```
+fastlane increment_framework_version
+```
+Increment framework version
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
This supports building the app via fastlane. Currently it works without bundler since fastlane itself provides support for version checking. To deploy a new build just execute: 

`fastlane release framework:SHDataFormatter version:0.0.1 path:"/User/name/development/yourPod"`

If you just want to run the tests, execute:

`fastlane run_framework_tests framework:SHDataFormatter path:"/User/name/development/yourPod"`

The path is necessary since I plan to reuse the Fastfile by storing it in a central place (maybe as Github Gist), pull it on demand and release this way. This is useful since I have multiple pods that all can be built using this Fastfile.