### PR TITLE
Allow Optional Value Input

### DIFF
--- a/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -29,16 +29,6 @@
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "607FACE41AFB9204008FA782"
-               BuildableName = "iOS Example_Tests.xctest"
-               BlueprintName = "iOS Example_Tests"
-               ReferencedContainer = "container:iOS Example.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -21,4 +21,3 @@ class ViewController: UIViewController {
     }
 
 }
-

--- a/Source/SHDateFormatter.swift
+++ b/Source/SHDateFormatter.swift
@@ -88,8 +88,12 @@ public struct SHDateFormatter {
      * - parameter format: The format used for the conversion.
      * - returns: A String object representing the date.
      */
-    public func stringFromDate(date: Date, format: SHDateFormat, locale: Locale? = nil, timeZone: TimeZone? = nil) -> String {
+    public func stringFromDate(date: Date?, format: SHDateFormat, locale: Locale? = nil, timeZone: TimeZone? = nil) -> String {
         var dateString: String = ""
+
+        guard let date = date else {
+            return dateString
+        }
 
         SHDateFormatter.serialDispatchQueue.sync {
             configureForDateFormat(format: format, locale: locale, timeZone: timeZone)
@@ -105,8 +109,12 @@ public struct SHDateFormatter {
      * - parameter format: The format used for the conversion.
      * - returns: A Date object representing the date.
      */
-    public func dateFromString(dateString: String, format: SHDateFormat, locale: Locale? = nil, timeZone: TimeZone? = nil) -> Date? {
+    public func dateFromString(dateString: String?, format: SHDateFormat, locale: Locale? = nil, timeZone: TimeZone? = nil) -> Date? {
         var date: Date?
+
+        guard let dateString = dateString else {
+            return date
+        }
 
         SHDateFormatter.serialDispatchQueue.sync {
             configureForDateFormat(format: format, locale: locale, timeZone: timeZone)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,7 @@ lane :run_framework_tests do |options|
   if !options[:framework]
     raise "No framework specified".red
   end
+
   framework = options[:framework]
   workspace = "#{framework}.xcworkspace"
 
@@ -90,12 +91,8 @@ desc "Pushes releases to github"
 desc "Commits and pushes changes to remote and tags the release commit"
 lane :release_to_cocoapods do |options|
 
-  if !options[:version]
-    raise "No version specified".red
-  end
-
-  if !options[:framework]
-    raise "No framework specified".red
+  if !options[:framework] || !options[:version]
+    raise "No framework or no version specified".red
   end
 
   framework = options[:framework]
@@ -142,12 +139,8 @@ end
 desc "Increments CFBundleVersion by one and sets CFBundleShortVersionString"
 private_lane :increment_framework_version do |options|
 
-  if !options[:version]
-    raise "No version specified".red
-  end
-
-  if !options[:framework]
-    raise "No framework specified".red
+  if !options[:framework] || !options[:version]
+    raise "No framework or no version specified".red
   end
 
   framework = options[:framework]
@@ -186,6 +179,7 @@ private_lane :push_framework_podspec do |options|
   if !options[:framework]
     raise "No framework specified".red
   end
+  
   framework = options[:framework]
   podspec = "#{framework}.podspec"
 
@@ -197,12 +191,8 @@ end
 desc "Creates a github release with a git commit changelog"
 private_lane :push_github_release do |options|
 
-  if !options[:version]
-    raise "No version specified".red
-  end
-
-  if !options[:framework]
-    raise "No framework specified".red
+  if !options[:framework] || !options[:version]
+    raise "No framework or no version specified".red
   end
 
   framework = options[:framework]


### PR DESCRIPTION
It is now possible to use optionals as parameters. If the value to convert is nil the default is returned (nil for string->date or an empty string for date->string).