### PR TITLE
Reset Locale to Current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#14](https://github.com/Blackjacx/SHDateFormatter/pull/14): Reset Locale to Current - [@blackjacx](https://github.com/blackjacx).
 * [#13](https://github.com/Blackjacx/SHDateFormatter/pull/13): Add SPM Support - [@blackjacx](https://github.com/blackjacx).
 
 ## [1.3.0] - 2019-05-06

--- a/Tests/DateFormatterSpec.swift
+++ b/Tests/DateFormatterSpec.swift
@@ -20,7 +20,7 @@ class DateFormatterSpec: QuickSpec {
             let gmtZone = TimeZone(identifier: "Europe/London")!
 
             let deDE_Locale = Locale(identifier: "de_DE")
-            let enEN_Locale = Locale(identifier: "en_EN")
+            let enEN_Locale = Locale(identifier: "en_US")
             let frFR_Locale = Locale(identifier: "fr_FR")
 
             func dateFrom(year: Int, month: Int, day: Int, hour: Int, min: Int, sec: Int) -> Date {

--- a/source/Classes/SHDateFormatter.swift
+++ b/source/Classes/SHDateFormatter.swift
@@ -79,8 +79,7 @@ public struct SHDateFormatter {
         SHDateFormatter.formatter.dateFormat = nil
         SHDateFormatter.formatter.timeStyle = .none
         SHDateFormatter.formatter.dateStyle = .none
-        // http://www.alexcurylo.com/2011/02/16/tip-nsdateformatter-localization/
-        SHDateFormatter.formatter.locale = Locale(identifier: Locale.preferredLanguages[0])
+        SHDateFormatter.formatter.locale = Locale.current
         SHDateFormatter.formatter.timeZone = TimeZone.current
     }
 


### PR DESCRIPTION
Previously I read an [article](http://www.alexcurylo.com/2011/02/16/tip-nsdateformatter-localization/) that suggested to set the locale of the date formatter to `Locale(identifier: Locale.preferredLanguages[0])` by default. This led to the issue that 24/12h time format was not applied correctly. 

By setting the locale to `Locale.current` by default this problem is solved. If this ever makes problems with Japanese calendars (as described in the article). I'll tackle this problem again.