### PR TITLE
Add `noDayShortMonthShortYear` to `SHDateFormat`

### DIFF
--- a/Source/SHDateFormatter/Classes/SHDateFormatter.swift
+++ b/Source/SHDateFormatter/Classes/SHDateFormatter.swift
@@ -13,6 +13,7 @@ public enum SHDateFormat: String {
     case longYear                   = "yyyy"
     case shortYearMonth             = "MMM yy"
     case longYearMonth              = "MMMM yyyy"
+    case noDayShortMonthShortYear   = "MM yy"
     case shortTimeNoDate
     case shortTimeMediumDate
     case noTimeShortDateNoYear      = "d.M."
@@ -56,7 +57,7 @@ public struct SHDateFormatter {
 
         switch format {
         case .shortWeekday, .longWeekday, .shortMonth, .longMonth, .longYear, .shortYear, .noTimeShortDateNoYear,
-             .shortYearMonth, .longYearMonth:
+                .shortYearMonth, .longYearMonth, .noDayShortMonthShortYear:
             SHDateFormatter.formatter.dateFormat = DateFormatter.dateFormat(fromTemplate: format.rawValue,
                                                                             options: 0,
                                                                             locale: locale)
@@ -123,7 +124,7 @@ public struct SHDateFormatter {
 
         switch format {
         case .shortWeekday, .longWeekday, .shortMonth, .longMonth, .shortYear,
-                .longYear, .shortYearMonth, .longYearMonth, .shortTimeNoDate,
+                .longYear, .shortYearMonth, .longYearMonth, .noDayShortMonthShortYear, .shortTimeNoDate,
                 .shortTimeMediumDate, .noTimeShortDateNoYear, .noTimeShortDate,
                 .noTimeLongDate, .noTimeIso8601Date:
 
@@ -169,7 +170,7 @@ public struct SHDateFormatter {
 
             switch format {
             case .shortWeekday, .longWeekday, .shortMonth, .longMonth, .shortYear,
-                    .longYear, .shortYearMonth, .longYearMonth, .shortTimeNoDate,
+                    .longYear, .shortYearMonth, .longYearMonth, .noDayShortMonthShortYear, .shortTimeNoDate,
                     .shortTimeMediumDate, .noTimeShortDateNoYear, .noTimeShortDate,
                     .noTimeLongDate, .noTimeIso8601Date:
 

--- a/Tests/SHDateFormatterTests/DateFormatterTests.swift
+++ b/Tests/SHDateFormatterTests/DateFormatterTests.swift
@@ -147,6 +147,14 @@ final class DateFormatterTests: QuickSpec {
                             expect(result) == "2000"
                         }
 
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: deDELocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01.00"
+                        }
+                        
                         it("ShortTimeNoDate") {
                             let result = SHDateFormatter.shared.string(from: testDate,
                                                                        format: .shortTimeNoDate,
@@ -252,6 +260,14 @@ final class DateFormatterTests: QuickSpec {
                                                                        locale: enUSLocale,
                                                                        timeZone: gmtZone)
                             expect(result) == "2000"
+                        }
+                        
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: enUSLocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01/00"
                         }
 
                         it("ShortTimeNoDate") {
@@ -359,6 +375,14 @@ final class DateFormatterTests: QuickSpec {
                                                                        locale: frFRLocale,
                                                                        timeZone: gmtZone)
                             expect(result) == "2000"
+                        }
+                        
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: frFRLocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01/00"
                         }
 
                         it("ShortTimeNoDate") {
@@ -480,6 +504,14 @@ final class DateFormatterTests: QuickSpec {
                                                                        timeZone: gmtZone)
                             expect(result) == "2000"
                         }
+                        
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: deDELocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01.00"
+                        }
 
                         it("ShortTimeNoDate") {
                             let result = SHDateFormatter.shared.string(from: testDate,
@@ -587,6 +619,14 @@ final class DateFormatterTests: QuickSpec {
                                                                        timeZone: gmtZone)
                             expect(result) == "2000"
                         }
+                        
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: enUSLocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01/00"
+                        }
 
                         it("ShortTimeNoDate") {
                             let result = SHDateFormatter.shared.string(from: testDate,
@@ -693,6 +733,14 @@ final class DateFormatterTests: QuickSpec {
                                                                        locale: frFRLocale,
                                                                        timeZone: gmtZone)
                             expect(result) == "2000"
+                        }
+                        
+                        it("NoDayShortMonthShortYear") {
+                            let result = SHDateFormatter.shared.string(from: testDate,
+                                                                       format: .noDayShortMonthShortYear,
+                                                                       locale: frFRLocale,
+                                                                       timeZone: gmtZone)
+                            expect(result) == "01/00"
                         }
 
                         it("ShortTimeNoDate") {


### PR DESCRIPTION
## Changed
- Added a new date format to generate a string that includes only month and year in the number form. 

## Example
- 18/07/2023 (en_US)  ->  07/23
- 18.07.2023 (de_DE)   ->  07.23